### PR TITLE
Migrate static content to dynamic Supabase hooks

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -106,6 +106,10 @@ padding-bottom: 200px;
   border: solid 4px #fff;
 }
 
+.profile-text {
+  text-align: center;
+}
+
 /* Type selectors*/
 
 h1 {

--- a/index.html
+++ b/index.html
@@ -6,6 +6,7 @@
   <title>Daz Gordon</title>
   <link rel="stylesheet"href="css/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
+  <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
   </head>
   <body>
 
@@ -13,42 +14,32 @@
     <div class="topnav">
 
       <ul class="topnav">
-      <li><a href="index.html">Home</a></li>
-      <li><a href="https://medium.com/@DazGordon">Blog</a></li>
-
       </ul>
     </div>
 
   <header id="top" class="main-header">
-
   <img class="profile" src="img/daz.jpg" alt="Daz">
-     <h1>Daz Gordon</h1>
-     <h2>PRODUCT MANAGER AT BREWDOG</H2>
-  <p>Hi, my name is Daz Gordon.</p>
-  <p>I work for BrewDog overseeing the roadmap of the website and apps</p>
-  <p> Full website coming soon</p>
-  <!-- Add font awesome icons -->
-<a href="https://uk.linkedin.com/in/daz-gordon-0376b8186" class="fa fa-linkedin"></a>
-<a href="https://www.instagram.com/sometimessunnydaz/?" class="fa fa-instagram"></a>
-
-   </header>
-
-
-
-<!--remove footer for now
- <section id="contact">
-   <h2>Contact</h2>
-   <h3>Get in touch if you fancy meeting for a coffee or beer</h3>
- <p><strong>Email:</strong><a href="mailto:contact@example.com?subject=Hi%20Daz!">contact@example.com</a></p>
- <p><strong>Phone:</strong> 555-123-4567</p>
-   <address>
-   TBC<br />
-   Edinburgh<br />
-   </address>
+    <div class="profile-text">
+      <h1>Daz Gordon</h1>
+      <h2>PRODUCT MANAGER AT BREWDOG</h2>
+      <p>Hi, my name is Daz Gordon.</p>
+      <p>I work for BrewDog overseeing the roadmap of the website and apps</p>
+      <p>Full website coming soon</p>
+      <!-- Add font awesome icons -->
+      <a href="https://uk.linkedin.com/in/daz-gordon-0376b8186" class="fa fa-linkedin"></a>
+      <a href="https://www.instagram.com/sometimessunnydaz/?" class="fa fa-instagram"></a>
+    </div>
+  </header>
 
 
- </section>
--->
+
+  <section id="contact">
+    <h2>Contact</h2>
+    <h3>Get in touch if you fancy meeting for a coffee or beer</h3>
+    <p><strong>Email:</strong> <a class="email" href="#">contact@example.com</a></p>
+    <p><strong>Phone:</strong> <span class="phone">555-123-4567</span></p>
+    <address></address>
+  </section>
 
       <!-- Footer -->
 
@@ -56,6 +47,7 @@
     <p>&copy;Daz Gordon 2020</p>
     <p><a href="#top">back to top</a></p>
       </footer>
+  <script src="js/main.js"></script>
   </body>
 
 </html>

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,76 @@
+// Placeholder configuration - replace with your Supabase project credentials
+const supabaseUrl = 'https://YOUR_SUPABASE_URL.supabase.co';
+const supabaseKey = 'YOUR_SUPABASE_ANON_KEY';
+const supabase = supabase.createClient(supabaseUrl, supabaseKey);
+
+async function loadNavigation() {
+  const { data, error } = await supabase
+    .from('navigation')
+    .select('title,url')
+    .order('position');
+  if (error) {
+    console.error('Failed to load navigation:', error);
+    return;
+  }
+  const navList = document.querySelector('.topnav ul');
+  navList.innerHTML = '';
+  data.forEach(item => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = item.url;
+    a.textContent = item.title;
+    li.appendChild(a);
+    navList.appendChild(li);
+  });
+}
+
+async function loadProfile() {
+  const { data, error } = await supabase
+    .from('profile')
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Failed to load profile:', error);
+    return;
+  }
+  document.querySelector('.profile').src = data.image_url;
+  document.querySelector('h1').textContent = data.name;
+  document.querySelector('h2').textContent = data.title;
+  const paragraphs = document.querySelectorAll('.profile-text p');
+  if (paragraphs[0]) paragraphs[0].textContent = data.intro_line1;
+  if (paragraphs[1]) paragraphs[1].textContent = data.intro_line2;
+}
+
+async function loadContact() {
+  const { data, error } = await supabase
+    .from('contact')
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Failed to load contact info:', error);
+    return;
+  }
+  document.querySelector('#contact .email').textContent = data.email;
+  document.querySelector('#contact .email').href = 'mailto:' + data.email;
+  document.querySelector('#contact .phone').textContent = data.phone;
+  document.querySelector('#contact address').innerHTML = data.address_html;
+}
+
+async function loadFooter() {
+  const { data, error } = await supabase
+    .from('footer')
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Failed to load footer:', error);
+    return;
+  }
+  document.querySelector('#main-footer p').innerHTML = data.text;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadNavigation();
+  await loadProfile();
+  await loadContact();
+  await loadFooter();
+});

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /admin/


### PR DESCRIPTION
## Summary
- add placeholder Supabase JS client implementation
- load navigation, profile, contact and footer dynamically
- style `.profile-text`
- prevent `/admin` from being indexed via `robots.txt`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684d3d61ddac832fa5a9a3b53d23dde5