### PR TITLE
Add dynamic about and contact pages

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,4 @@
+node_modules/
+package-lock.json
+.DS_Store
+

--- a/about.html
+++ b/about.html
@@ -3,35 +3,33 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Daz Gordon</title>
-  <link rel="stylesheet"href="css/style.css">
+  <title>About - Daz Gordon</title>
+  <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  </head>
-  <body>
-
-    <!-- Top navigation -->
-    <div class="topnav">
-
-      <ul class="topnav">
-      </ul>
-    </div>
+</head>
+<body>
+  <!-- Top navigation -->
+  <div class="topnav">
+    <ul class="topnav"></ul>
+  </div>
 
   <header id="top" class="main-header">
-  <img class="profile" src="img/daz.jpg" alt="Daz">
+    <img class="profile" src="img/daz.jpg" alt="Daz">
     <div class="profile-text">
       <h1>Daz Gordon</h1>
       <h2>PRODUCT MANAGER AT BREWDOG</h2>
       <p>Hi, my name is Daz Gordon.</p>
       <p>I work for BrewDog overseeing the roadmap of the website and apps</p>
       <p>Full website coming soon</p>
-      <!-- Add font awesome icons -->
       <a href="https://uk.linkedin.com/in/daz-gordon-0376b8186" class="fa fa-linkedin"></a>
       <a href="https://www.instagram.com/sometimessunnydaz/?" class="fa fa-instagram"></a>
     </div>
   </header>
 
-
+  <section id="about">
+    <div class="about-content"></div>
+  </section>
 
   <section id="contact">
     <h2>Contact</h2>
@@ -41,13 +39,10 @@
     <address></address>
   </section>
 
-      <!-- Footer -->
-
   <footer id="main-footer">
     <p>&copy;Daz Gordon 2020</p>
     <p><a href="#top">back to top</a></p>
-      </footer>
+  </footer>
   <script src="js/main.js"></script>
-  </body>
-
+</body>
 </html>

--- a/contact.html
+++ b/contact.html
@@ -3,35 +3,29 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Daz Gordon</title>
-  <link rel="stylesheet"href="css/style.css">
+  <title>Contact - Daz Gordon</title>
+  <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  </head>
-  <body>
-
-    <!-- Top navigation -->
-    <div class="topnav">
-
-      <ul class="topnav">
-      </ul>
-    </div>
+</head>
+<body>
+  <!-- Top navigation -->
+  <div class="topnav">
+    <ul class="topnav"></ul>
+  </div>
 
   <header id="top" class="main-header">
-  <img class="profile" src="img/daz.jpg" alt="Daz">
+    <img class="profile" src="img/daz.jpg" alt="Daz">
     <div class="profile-text">
       <h1>Daz Gordon</h1>
       <h2>PRODUCT MANAGER AT BREWDOG</h2>
       <p>Hi, my name is Daz Gordon.</p>
       <p>I work for BrewDog overseeing the roadmap of the website and apps</p>
       <p>Full website coming soon</p>
-      <!-- Add font awesome icons -->
       <a href="https://uk.linkedin.com/in/daz-gordon-0376b8186" class="fa fa-linkedin"></a>
       <a href="https://www.instagram.com/sometimessunnydaz/?" class="fa fa-instagram"></a>
     </div>
   </header>
-
-
 
   <section id="contact">
     <h2>Contact</h2>
@@ -41,13 +35,10 @@
     <address></address>
   </section>
 
-      <!-- Footer -->
-
   <footer id="main-footer">
     <p>&copy;Daz Gordon 2020</p>
     <p><a href="#top">back to top</a></p>
-      </footer>
+  </footer>
   <script src="js/main.js"></script>
-  </body>
-
+</body>
 </html>

--- a/css/style.css
+++ b/css/style.css
@@ -106,6 +106,10 @@ padding-bottom: 200px;
   border: solid 4px #fff;
 }
 
+.profile-text {
+  text-align: center;
+}
+
 /* Type selectors*/
 
 h1 {
@@ -182,6 +186,15 @@ background-color: #6dc4f0;
 .fa-instagram {
   background: #000;
   color: white;
+}
+
+.services-list {
+  list-style: none;
+  padding: 0;
+}
+
+.services-list li {
+  margin-bottom: 1em;
 }
 
 

--- a/js/main.js
+++ b/js/main.js
@@ -1,0 +1,116 @@
+// Placeholder configuration - replace with your Supabase project credentials
+const supabaseUrl = 'https://YOUR_SUPABASE_URL.supabase.co';
+const supabaseKey = 'YOUR_SUPABASE_ANON_KEY';
+const client = window.supabase.createClient(supabaseUrl, supabaseKey);
+
+async function loadNavigation() {
+  const { data, error } = await client
+    .from('navigation')
+    .select('title,url')
+    .order('position');
+  if (error) {
+    console.error('Failed to load navigation:', error);
+    return;
+  }
+  const navList = document.querySelector('.topnav ul');
+  navList.innerHTML = '';
+  data.forEach(item => {
+    const li = document.createElement('li');
+    const a = document.createElement('a');
+    a.href = item.url;
+    a.textContent = item.title;
+    li.appendChild(a);
+    navList.appendChild(li);
+  });
+}
+
+async function loadProfile() {
+  const { data, error } = await client
+    .from('profile')
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Failed to load profile:', error);
+    return;
+  }
+  document.querySelector('.profile').src = data.image_url;
+  document.querySelector('h1').textContent = data.name;
+  document.querySelector('h2').textContent = data.title;
+  const paragraphs = document.querySelectorAll('.profile-text p');
+  if (paragraphs[0]) paragraphs[0].textContent = data.intro_line1;
+  if (paragraphs[1]) paragraphs[1].textContent = data.intro_line2;
+}
+
+async function loadContact() {
+  const { data, error } = await client
+    .from('contact')
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Failed to load contact info:', error);
+    return;
+  }
+  document.querySelector('#contact .email').textContent = data.email;
+  document.querySelector('#contact .email').href = 'mailto:' + data.email;
+  document.querySelector('#contact .phone').textContent = data.phone;
+  document.querySelector('#contact address').innerHTML = data.address_html;
+}
+
+async function loadFooter() {
+  const { data, error } = await client
+    .from('footer')
+    .select('*')
+    .single();
+  if (error) {
+    console.error('Failed to load footer:', error);
+    return;
+  }
+  document.querySelector('#main-footer p').innerHTML = data.text;
+}
+
+async function loadAbout() {
+  const aboutSection = document.querySelector('#about .about-content');
+  if (!aboutSection) return;
+  const { data, error } = await client
+    .from('about')
+    .select('content_html')
+    .single();
+  if (error) {
+    console.error('Failed to load about content:', error);
+    return;
+  }
+  aboutSection.innerHTML = data.content_html;
+}
+
+document.addEventListener('DOMContentLoaded', async () => {
+  await loadNavigation();
+  await loadProfile();
+  await loadContact();
+  await loadFooter();
+  await loadAbout();
+  await loadServices();
+});
+
+async function loadServices() {
+  const servicesList = document.querySelector('#services .services-list');
+  if (!servicesList) return;
+  const { data, error } = await client
+    .from('services')
+    .select('title,description')
+    .order('position');
+  if (error) {
+    console.error('Failed to load services:', error);
+    return;
+  }
+  servicesList.innerHTML = '';
+  data.forEach(service => {
+    const li = document.createElement('li');
+    const title = document.createElement('h3');
+    title.textContent = service.title;
+    const desc = document.createElement('p');
+    desc.textContent = service.description;
+    li.appendChild(title);
+    li.appendChild(desc);
+    servicesList.appendChild(li);
+  });
+}

--- a/robots.txt
+++ b/robots.txt
@@ -1,0 +1,2 @@
+User-agent: *
+Disallow: /admin/

--- a/services.html
+++ b/services.html
@@ -3,35 +3,34 @@
 <head>
   <meta charset="UTF-8">
   <meta name="viewport" content="width=device-width, initial-scale=1.0">
-  <title>Daz Gordon</title>
-  <link rel="stylesheet"href="css/style.css">
+  <title>Services - Daz Gordon</title>
+  <link rel="stylesheet" href="css/style.css">
   <link rel="stylesheet" href="https://cdnjs.cloudflare.com/ajax/libs/font-awesome/4.7.0/css/font-awesome.min.css">
   <script src="https://cdn.jsdelivr.net/npm/@supabase/supabase-js@2"></script>
-  </head>
-  <body>
-
-    <!-- Top navigation -->
-    <div class="topnav">
-
-      <ul class="topnav">
-      </ul>
-    </div>
+</head>
+<body>
+  <!-- Top navigation -->
+  <div class="topnav">
+    <ul class="topnav"></ul>
+  </div>
 
   <header id="top" class="main-header">
-  <img class="profile" src="img/daz.jpg" alt="Daz">
+    <img class="profile" src="img/daz.jpg" alt="Daz">
     <div class="profile-text">
       <h1>Daz Gordon</h1>
       <h2>PRODUCT MANAGER AT BREWDOG</h2>
       <p>Hi, my name is Daz Gordon.</p>
       <p>I work for BrewDog overseeing the roadmap of the website and apps</p>
       <p>Full website coming soon</p>
-      <!-- Add font awesome icons -->
       <a href="https://uk.linkedin.com/in/daz-gordon-0376b8186" class="fa fa-linkedin"></a>
       <a href="https://www.instagram.com/sometimessunnydaz/?" class="fa fa-instagram"></a>
     </div>
   </header>
 
-
+  <section id="services">
+    <h2>Services</h2>
+    <ul class="services-list"></ul>
+  </section>
 
   <section id="contact">
     <h2>Contact</h2>
@@ -41,13 +40,10 @@
     <address></address>
   </section>
 
-      <!-- Footer -->
-
   <footer id="main-footer">
     <p>&copy;Daz Gordon 2020</p>
     <p><a href="#top">back to top</a></p>
-      </footer>
+  </footer>
   <script src="js/main.js"></script>
-  </body>
-
+</body>
 </html>


### PR DESCRIPTION
## Summary
- introduce `about.html` and `contact.html` as Supabase-driven pages
- load about content via new `loadAbout` function
- trigger the new loader on DOMContentLoaded
- keep `/admin` disallowed in `robots.txt`

## Testing
- `npm test` *(fails: Could not read package.json)*
- `pytest` *(no tests ran)*

------
https://chatgpt.com/codex/tasks/task_e_684d3d61ddac832fa5a9a3b53d23dde5